### PR TITLE
Update 20250408 to 4.9.25098

### DIFF
--- a/.github/workflows/add_fastani_ref.yml
+++ b/.github/workflows/add_fastani_ref.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ecoli.yml
+++ b/.github/workflows/ecoli.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/just_msa.yml
+++ b/.github/workflows/just_msa.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/klebsiella.yml
+++ b/.github/workflows/klebsiella.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/legionella.yml
+++ b/.github/workflows/legionella.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/myco.yml
+++ b/.github/workflows/myco.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/phylogenetic_workflow.yml
+++ b/.github/workflows/phylogenetic_workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prokka.yml
+++ b/.github/workflows/prokka.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prokka_roary.yml
+++ b/.github/workflows/prokka_roary.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/roary.yml
+++ b/.github/workflows/roary.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/salmonella.yml
+++ b/.github/workflows/salmonella.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sample_sheet.yml
+++ b/.github/workflows/sample_sheet.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/strepA.yml
+++ b/.github/workflows/strepA.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/strep_pneumo.yml
+++ b/.github/workflows/strep_pneumo.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test0.yml
+++ b/.github/workflows/test0.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test1.yml
+++ b/.github/workflows/test1.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test3.yml
+++ b/.github/workflows/test3.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test4.yml
+++ b/.github/workflows/test4.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test5.yml
+++ b/.github/workflows/test5.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test6.yml
+++ b/.github/workflows/test6.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test7.yml
+++ b/.github/workflows/test7.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test8.yml
+++ b/.github/workflows/test8.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/vibrio.yml
+++ b/.github/workflows/vibrio.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/withoutfastani.yml
+++ b/.github/workflows/withoutfastani.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -14,7 +14,6 @@ lint:
     - "manifest.homePage"
 nf_core_version: 3.0.2
 org_path: null
-repository_type: pipeline
 template:
   author: Erin Young
   description: reference free assembly and typing

--- a/bin/.tests.sh
+++ b/bin/.tests.sh
@@ -1,18 +1,18 @@
 #/bin/bash
 
 # just a bunch of tests with local directories
-# /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur/bin/.tests.sh
+# /Volumes/NGS_2/Bioinformatics/eriny/Grandeur/bin/.tests.sh
 
 # default with input
-nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
   -profile singularity \
-  --sample_sheet /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur/bin/sample_sheet.csv \
+  --sample_sheet /Volumes/NGS_2/Bioinformatics/eriny/Grandeur/bin/sample_sheet.csv \
   --outdir grandeur_sample_sheet \
   -resume  \
   -with-tower
 
 # default with reads
-nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
   -profile singularity \
   --reads  /home/eriny/sandbox/test_files/grandeur/reads \
   --outdir grandeur_fastq_channel \
@@ -20,7 +20,7 @@ nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
   -with-tower
 
 # default with fastas
-nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
   -profile singularity \
   --fastas /home/eriny/sandbox/test_files/grandeur/fastas \
   --outdir grandeur_fasta_channel \
@@ -28,7 +28,7 @@ nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
   -with-tower
 
 # default with reads and fastas
-nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
   -profile singularity \
   --reads  /home/eriny/sandbox/test_files/grandeur/reads \
   --fastas /home/eriny/sandbox/test_files/grandeur/fastas \
@@ -37,7 +37,7 @@ nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
   -with-tower
 
 # multiple sequence alignment
-nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
   -profile singularity,msa \
   --gff    /home/eriny/sandbox/test_files/grandeur/msa \
   --fastas /home/eriny/sandbox/test_files/grandeur/msa \
@@ -51,7 +51,7 @@ for profile in "singularity" "uphl"
 do
   for ver in "test0" "test1" "test2" "test3" "test4" "test5" "test6"
   do
-    nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+    nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
       -profile $profile,$ver \
       --outdir grandeur_${ver}_$profile \
       -resume  \
@@ -60,7 +60,7 @@ do
 done
 
 # with nothing
-nextflow run /Volumes/IDGenomics_NAS/Bioinformatics/eriny/Grandeur \
+nextflow run /Volumes/NGS_2/Bioinformatics/eriny/Grandeur \
   -profile singularity \
   --gff    wontexist \
   --fastas shouldntexit \

--- a/conf/UPHL.config
+++ b/conf/UPHL.config
@@ -1,8 +1,7 @@
 docker.enabled          = true
 docker.runOptions       = '-u $(id -u):$(id -g)'
 
-params.blast_db         = '/Volumes/IDGenomics_NAS/Data/refseq/222/blast_db/'
+params.blast_db         = '/Volumes/NGS_2/Data/refseq/222/blast_db/'
 params.blast_db_type    = 'ref_prok_rep_genomes'
-params.kraken2_db       = '/Volumes/IDGenomics_NAS/Data/kraken2_db/2023-06-05'
-params.mash_db          = '/Volumes/IDGenomics_NAS/Data/refseq/222/mash/rep-genomes.msh'
-
+params.kraken2_db       = '/Volumes/NGS_2/Data/kraken2_db/2023-06-05'
+params.mash_db          = '/Volumes/NGS_2/Data/refseq/222/mash/rep-genomes.msh'

--- a/modules/local/amrfinderplus.nf
+++ b/modules/local/amrfinderplus.nf
@@ -1,7 +1,7 @@
 process AMRFINDER {
   tag           "${meta.id}"
   label         "process_high"
-  container     'staphb/ncbi-amrfinderplus:4.0.15-2024-12-18.1'
+  container     'staphb/ncbi-amrfinderplus:4.0.19-2024-12-18.1'
 
   input:
   tuple val(meta), file(contigs), val(genus), val(species)

--- a/modules/local/bakta.nf
+++ b/modules/local/bakta.nf
@@ -1,7 +1,7 @@
 process BAKTA {
   tag           "${meta.id}"
   label         "process_high"
-  container     'staphb/bakta:1.10.3-5.1-light'
+  container     'staphb/bakta:1.10.4-5.1-light'
   time    '30m'
 
   input:

--- a/modules/local/datasets.nf
+++ b/modules/local/datasets.nf
@@ -1,7 +1,7 @@
 process DATASETS_SUMMARY {
   tag           "${taxon}"
   label         "process_single"
-  container     'staphb/ncbi-datasets:16.38.1'
+  container     'staphb/ncbi-datasets:16.41.0'
 
   input:
   tuple val(taxon), file(script)
@@ -47,7 +47,7 @@ process DATASETS_SUMMARY {
 process DATASETS_DOWNLOAD {
   tag           "Downloading Genomes"
   label         "process_medium"
-  container     'staphb/ncbi-datasets:16.35.0'
+  container     'staphb/ncbi-datasets:16.41.0'
   
   input:
   file(ids)

--- a/modules/local/elgato.nf
+++ b/modules/local/elgato.nf
@@ -1,7 +1,7 @@
 process ELGATO {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/elgato:1.20.2'
+  container     'staphb/elgato:1.21.0'
 
   input:
   tuple val(meta), file(contigs)

--- a/modules/local/iqtree2.nf
+++ b/modules/local/iqtree2.nf
@@ -1,7 +1,7 @@
 process IQTREE2 {
   tag           "Phylogenetic analysis"
   label         "process_high"
-  container     'staphb/iqtree2:2.3.6'
+  container     'staphb/iqtree2:2.4.0'
   
   input:
   file(msa)

--- a/modules/local/kleborate.nf
+++ b/modules/local/kleborate.nf
@@ -1,7 +1,7 @@
 process KLEBORATE {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/kleborate:3.1.2'
+  container     'staphb/kleborate:3.1.3'
 
   input:
   tuple val(meta), file(contig), file(script)

--- a/modules/local/mlst.nf
+++ b/modules/local/mlst.nf
@@ -1,7 +1,7 @@
 process MLST {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/mlst:2.23.0-2025-02-01'
+  container     'staphb/mlst:2.23.0-2024-12-31'
 
   input:
   tuple val(meta), file(contig), file(script)

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -1,7 +1,7 @@
 process MULTIQC {
   tag           "multiqc"
   label         "process_single"
-  container     'staphb/multiqc:1.26'
+  container     'staphb/multiqc:1.27.1'
 
   input:
   file(input)
@@ -38,7 +38,7 @@ process MULTIQC {
 process VERSIONS {
   tag           "extracting versions"
   label         "process_single"
-  container     'staphb/multiqc:1.26'
+  container     'staphb/multiqc:1.27.1'
 
   input:
   file(input)

--- a/modules/local/plasmidfinder.nf
+++ b/modules/local/plasmidfinder.nf
@@ -1,7 +1,7 @@
 process PLASMIDFINDER {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/plasmidfinder:2.1.6_2024-03-07'
+  container     'staphb/plasmidfinder:2.1.6_2025-02-19'
 
 
   input:

--- a/modules/local/spades.nf
+++ b/modules/local/spades.nf
@@ -1,7 +1,7 @@
 process SPADES {
   tag           "${meta.id}"
   label         "process_high"
-  container     'staphb/spades:4.0.0'
+  container     'staphb/spades:4.1.0'
   
   input:
   tuple val(meta), file(reads)

--- a/nextflow.config
+++ b/nextflow.config
@@ -196,7 +196,7 @@ manifest {
   author                          = 'Erin Young'
   homePage                        = 'https://github.com/UPHL-BioNGS/Grandeur'
   mainScript                      = 'main.nf'
-  version                         = '4.9.25035'
+  version                         = '4.9.25098'
   defaultBranch                   = 'main'
   description                     = 'Grandeur is short-read de novo assembly pipeline with serotyping.'
   nextflowVersion                 = '!>=24.04.4'


### PR DESCRIPTION

- update ncbi-amrfinderplus to 4.0.19-2024-12-18.1
- update bakta to 1.10.4-5.1-light
- update datasets to 16.41.0
- update el gato to 1.21.0
- update iqtree2 to 2.4.0
- update kleborate to 3.1.3
- update mlst to 2.23.0-2024-12-31 (see https://github.com/StaPH-B/docker-builds/issues/1169 for more information)
- update multiqc to 1.27.1
- update plasmidfinder to 2.1.6_2025-02-19
- update spades to 4.1.0






































