### PR TITLE
Update 4.9.25175

### DIFF
--- a/modules/local/amrfinderplus.nf
+++ b/modules/local/amrfinderplus.nf
@@ -1,7 +1,7 @@
 process AMRFINDER {
   tag           "${meta.id}"
   label         "process_high"
-  container     'staphb/ncbi-amrfinderplus:4.0.22-2025-03-25.1'
+  container     'staphb/ncbi-amrfinderplus:4.0.23-2025-06-03.1'
 
   input:
   tuple val(meta), file(contigs), val(genus), val(species)

--- a/modules/local/bakta.nf
+++ b/modules/local/bakta.nf
@@ -1,7 +1,7 @@
 process BAKTA {
   tag           "${meta.id}"
   label         "process_high"
-  container     'staphb/bakta:1.10.4-5.1-light'
+  container     'staphb/bakta:1.11.0-6.0-light'
   time    '30m'
 
   input:

--- a/modules/local/datasets.nf
+++ b/modules/local/datasets.nf
@@ -1,7 +1,7 @@
 process DATASETS_SUMMARY {
   tag           "${taxon}"
   label         "process_single"
-  container     'staphb/ncbi-datasets:16.41.0'
+  container     'staphb/ncbi-datasets:18.0.2'
 
   input:
   tuple val(taxon), file(script)
@@ -47,7 +47,7 @@ process DATASETS_SUMMARY {
 process DATASETS_DOWNLOAD {
   tag           "Downloading Genomes"
   label         "process_medium"
-  container     'staphb/ncbi-datasets:16.41.0'
+  container     'staphb/ncbi-datasets:18.0.2'
   
   input:
   file(ids)

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -38,7 +38,7 @@ process MULTIQC {
 process VERSIONS {
   tag           "extracting versions"
   label         "process_single"
-  container     'staphb/multiqc:1.27.1'
+  container     'staphb/multiqc:1.28'
 
   input:
   file(input)

--- a/modules/local/panaroo.nf
+++ b/modules/local/panaroo.nf
@@ -1,7 +1,7 @@
 process PANAROO {
   tag           "Core Genome Alignment"
   label         "process_high"
-  container     'staphb/panaroo:1.5.1'
+  container     'staphb/panaroo:1.5.2'
   
   input:
   file(gff)

--- a/modules/local/spades.nf
+++ b/modules/local/spades.nf
@@ -1,7 +1,7 @@
 process SPADES {
   tag           "${meta.id}"
   label         "process_high"
-  container     'staphb/spades:4.1.0'
+  container     'staphb/spades:4.2.0'
   
   input:
   tuple val(meta), file(reads)

--- a/nextflow.config
+++ b/nextflow.config
@@ -196,7 +196,7 @@ manifest {
   author                          = 'Erin Young'
   homePage                        = 'https://github.com/UPHL-BioNGS/Grandeur'
   mainScript                      = 'main.nf'
-  version                         = '4.9.25127'
+  version                         = '4.9.25175'
   defaultBranch                   = 'main'
   description                     = 'Grandeur is short-read de novo assembly pipeline with serotyping.'
   nextflowVersion                 = '!>=24.04.4'


### PR DESCRIPTION
Update to 4.9.25175

- Update bakta to 1.11.0-6.0-light
- Update multiqc to 1.28
- Update amrfinderplus to 4.0.23-2025-06-03.1
- Update datasets to 18.0.2
- Update panaroo to 1.5.2
- Update spades to 4.2.0